### PR TITLE
Various API fixes

### DIFF
--- a/MXCHIPInterface.cpp
+++ b/MXCHIPInterface.cpp
@@ -159,10 +159,11 @@ int MXCHIPInterface::socket_close(void *handle)
     int err = 0;
     _mxchip.setTimeout(MXCHIP_MISC_TIMEOUT);
 
-    if (!_mxchip.close(socket->socketId)) {
+    if (socket->connected && !_mxchip.close(socket->socketId)) {
         err = NSAPI_ERROR_DEVICE_ERROR;
     }
 
+    socket->connected = false;
     _ids[socket->id] = false;
     delete socket;
     return err;


### PR DESCRIPTION
* Now, the driver checks if a socket is connected before trying to close it. Without this check, the close call will fail if we close a socket that has not been connected to a server.
* We now track what IP address a socket is connected to. `recvfrom` expects that the interface will assign the `SocketAddress` pointer parameter to a valid IP address, so this change aligns with that.