### PR TITLE
Update reference to ATParser

### DIFF
--- a/mxchip/ATParser.lib
+++ b/mxchip/ATParser.lib
@@ -1,1 +1,1 @@
-https://github.com/sarahmarshy/ATParser/#1ea8ab87678e34c0dbdcc5cc7568233cf52dbf03
+https://github.com/ARMmbed/ATParser/#ce59d6454d632ac9e8a4b53250dc0367405c2374


### PR DESCRIPTION
The ATParser owned by ARMmbed has been updated with the changes we needed (https://github.com/ARMmbed/ATParser/pull/8). So, I'm updating the reference to it in this driver, and we can stop using my personal fork. 